### PR TITLE
qulice is failing during 'mvn qulice:check'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
                 </dependencies>
                 <executions>
                     <execution>
+                        <phase>compile</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,13 @@
                         <exclude>checkstyle:.*XmlConfigApplication.*</exclude>
                     </excludes>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                        <version>1.2</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
```java
pavel.k.danilin>mvn qulice:check
[INFO] Scanning for projects...
[INFO]
[INFO] -----------------------< org.example:test-task >------------------------
[INFO] Building test-task 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- qulice-maven-plugin:0.18.19:check (default-cli) @ test-task ---
Apr 22, 2021 3:29:59 PM net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'FieldDeclaration/@VariableName' in XPath query
[INFO] Checkstyle: xxx\pavel.k.danilin\src\main\java\org\example\testtask\controller\IntValueController.java[3]: Line does not mat
ch expected header line of ' *'. (HeaderCheck)
[INFO] Checkstyle: xxx\pavel.k.danilin\src\main\java\org\example\testtask\controller\IntValueController.java[4]: Lines in file sho
uld end with Unix-like end of line (RegexpMultilineCheck)
[INFO] Checkstyle: xxx\pavel.k.danilin\src\main\java\org\example\testtask\controller\IntValueController.java[6]: Lines in file sho
uld end with Unix-like end of line (RegexpMultilineCheck)
...
```